### PR TITLE
Support reading a local sitemap.xml

### DIFF
--- a/lib/sitemap-parser.rb
+++ b/lib/sitemap-parser.rb
@@ -9,15 +9,19 @@ class SitemapParser
 
   def raw_sitemap
     @raw_sitemap ||= begin
-      request = Typhoeus::Request.new(@url, followlocation: true)
-      request.on_complete do |response|
-        if response.success?
-          return response.body
-        else
-          return nil
+      if @url =~ /\Ahttp/i
+        request = Typhoeus::Request.new(@url, followlocation: true)
+        request.on_complete do |response|
+          if response.success?
+            return response.body
+          else
+            return nil
+          end
         end
+        request.run
+      elsif File.exist?(@url) && @url =~ /[\\\/]sitemap\.xml\Z/i
+        open(@url) { |f| f.read }
       end
-      request.run
     end
   end
 

--- a/test/test_sitemap_parser.rb
+++ b/test/test_sitemap_parser.rb
@@ -4,21 +4,30 @@ class TestSitemapParser < Test::Unit::TestCase
   def setup
     @url = "https://raw.githubusercontent.com/benbalter/sitemap-parser/master/test/fixtures/sitemap.xml"
     @sitemap = SitemapParser.new @url
+
+    @local_file = File.join(File.dirname(__FILE__), 'fixtures', 'sitemap.xml')
+    @local_sitemap = SitemapParser.new @local_file
+
     @expected_count = 3
   end
 
   def test_array
     assert_equal Array, @sitemap.to_a.class
     assert_equal @expected_count, @sitemap.to_a.count
+    assert_equal Array, @local_sitemap.to_a.class
+    assert_equal @expected_count, @local_sitemap.to_a.count
   end
 
   def test_xml
     assert_equal Nokogiri::XML::NodeSet, @sitemap.urls.class
     assert_equal @expected_count, @sitemap.urls.count
+    assert_equal Nokogiri::XML::NodeSet, @local_sitemap.urls.class
+    assert_equal @expected_count, @local_sitemap.urls.count
   end
 
   def test_sitemap
     assert_equal Nokogiri::XML::Document, @sitemap.sitemap.class
+    assert_equal Nokogiri::XML::Document, @local_sitemap.sitemap.class
   end
 
   def test_404


### PR DESCRIPTION
Sometimes you're doing some testing of stuff and you need to read the _sitemap.xml_ file locally. This supports that.

I realize the `@url` name is now a misnomer--I can change that to `path` (or something) if it 's preferred.
