### PR TITLE
Pass in opts for `followlocation`

### DIFF
--- a/lib/sitemap-parser.rb
+++ b/lib/sitemap-parser.rb
@@ -3,14 +3,15 @@ require 'typhoeus'
 
 class SitemapParser
 
-  def initialize(url)
+  def initialize(url, opts = {})
     @url = url
+    @options = {:followlocation => true}.merge(opts)
   end
 
   def raw_sitemap
     @raw_sitemap ||= begin
       if @url =~ /\Ahttp/i
-        request = Typhoeus::Request.new(@url, followlocation: true)
+        request = Typhoeus::Request.new(@url, followlocation: @options[:followlocation])
         request.on_complete do |response|
           if response.success?
             return response.body


### PR DESCRIPTION
Sometimes you don't want to `followlocation`.

Suppose you're navigating a sitemap and you're fetching the content.  URL A has a redirect to URL B. In that instance, fetching URL A and URL B yields the same information. But you don't necessarily give a hoot about URL A in this instance.
