### PR TITLE
Bump up Typheous dependency

### DIFF
--- a/sitemap-parser.gemspec
+++ b/sitemap-parser.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
   s.files = [ "lib/sitemap-parser.rb" ]
   s.add_dependency("nokogiri","~> 1.5.6")
-  s.add_dependency("typhoeus", "~> 0.6.7")
+  s.add_dependency("typhoeus", "~> 0.6")
 end


### PR DESCRIPTION
This is actually super important. Typheous@0.6.8 fixed a conflict with Farday@0.9.0: https://github.com/typhoeus/typhoeus/commit/b169bc3dc83e45812fd284664156873172b88e6f

Projects using both this gem and Faraday@0.9.0 experience an error: 

```
Ethon::Errors::InvalidOption: The option: disable_ssl_peer_verification is invalid.
Please try ssl_verifypeer instead of disable_ssl_peer_verification.
```
