### PR TITLE
allow typhoeus versions up to 2.0

### DIFF
--- a/sitemap-parser.gemspec
+++ b/sitemap-parser.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT"]
   s.files = [ "lib/sitemap-parser.rb" ]
   s.add_dependency("nokogiri","~> 1.6")
-  s.add_dependency("typhoeus", "~> 0.6")
+  s.add_dependency("typhoeus", ">= 0.6", "< 2.0")
   s.add_development_dependency("rake", "~> 10.4")
   s.add_development_dependency("shoulda", "~> 3.5")
   s.add_development_dependency("bundler", "~> 1.6")


### PR DESCRIPTION
Relaxing the typhoeus version constraint to allow usage in repos requiring typhoeus > 1.0.