### PR TITLE
Remove breaking reference to version

### DIFF
--- a/lib/sitemap-parser.rb
+++ b/lib/sitemap-parser.rb
@@ -3,7 +3,6 @@
 require 'nokogiri'
 require 'typhoeus'
 require 'zlib'
-require_relative 'sitemap-parser/version'
 
 class SitemapParser
   def initialize(url, opts = {})


### PR DESCRIPTION
Not sure if the reference to the version is required or not. 

Pulling to fix: https://github.com/benbalter/sitemap-parser/issues/21