### PR TITLE
Fixed a require error.

### DIFF
--- a/lib/sitemap-parser/version.rb
+++ b/lib/sitemap-parser/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class SitemapParser
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end

--- a/sitemap-parser.gemspec
+++ b/sitemap-parser.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.email = 'ben.balter@github.com'
   s.homepage = 'https://github.com/benbalter/sitemap-parser'
   s.licenses = ['MIT']
-  s.files = ['lib/sitemap-parser.rb']
+  s.files = ['lib/sitemap-parser.rb', 'lib/sitemap-parser/version.rb']
   s.add_dependency('nokogiri', '~> 1.6')
   s.add_dependency('typhoeus', '>= 0.6', '< 2.0')
   s.add_development_dependency('minitest', '~> 4.7')


### PR DESCRIPTION
When I tried to use sitemap-parser using gem install, I couldn't require it, so I'll fix it in this PR.
Pulling to fix: #21

This problem is caused by the fact that version.rb is not included in the gem file as shown in the comment below.

https://github.com/benbalter/sitemap-parser/pull/22#issuecomment-993482353

My environment is as follows.

```
@yubele ➜ /workspaces/sitemap-parser (fix/require) $ ruby -v
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]
@yubele ➜ /workspaces/sitemap-parser (fix/require) $ irb -v
irb 1.2.6 (2020-09-14)
```

The following is the operation that caused the error.

```
@yubele ➜ /workspaces/sitemap-parser (fix/require) $ gem install sitemap-parser -v 0.5.0
Fetching sitemap-parser-0.5.0.gem
Successfully installed sitemap-parser-0.5.0
1 gem installed
@yubele ➜ /workspaces/sitemap-parser (fix/require) $ irb
irb(main):001:0> require 'sitemap-parser'
Traceback (most recent call last):
        9: from /home/codespace/.ruby/current/bin/irb:23:in `<main>'
        8: from /home/codespace/.ruby/current/bin/irb:23:in `load'
        7: from /opt/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        6: from (irb):1
        5: from /opt/ruby/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:149:in `require'
        4: from /opt/ruby/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:160:in `rescue in require'
        3: from /opt/ruby/2.7.2/lib/ruby/site_ruby/2.7.0/rubygems/core_ext/kernel_require.rb:160:in `require'
        2: from /opt/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/sitemap-parser-0.5.0/lib/sitemap-parser.rb:6:in `<top (required)>'
        1: from /opt/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/sitemap-parser-0.5.0/lib/sitemap-parser.rb:6:in `require_relative'
LoadError (cannot load such file -- /opt/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/sitemap-parser-0.5.0/lib/sitemap-parser/version)
irb(main):002:0> 
```


The build result of this PR is as follows.
```
@yubele ➜ /workspaces/sitemap-parser (fix/require) $ gem install sitemap-parser
Successfully installed sitemap-parser-0.5.1
1 gem installed
@yubele ➜ /workspaces/sitemap-parser (fix/require) $ irb
irb(main):001:0> require 'sitemap-parser'
=> true
irb(main):002:0> exit
```
