### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: build
+
+on: [pull_request, push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - '2.4'
+          - '2.3'
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - run: bundle exec rake test

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,17 @@
+name: RuboCop
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true # 'bundle install' and cache
+    - name: Run RuboCop
+      run: bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-langauage: ruby
-script: "script/cibuild"
-sudo: false
-cache: bundler
-rvm:
-  - 2.1.0

--- a/sitemap-parser.gemspec
+++ b/sitemap-parser.gemspec
@@ -12,13 +12,14 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/benbalter/sitemap-parser'
   s.licenses = ['MIT']
   s.files = ['lib/sitemap-parser.rb', 'lib/sitemap-parser/version.rb']
-  s.add_dependency('nokogiri', '~> 1.6')
+  s.add_dependency('nokogiri', '>= 1.6')
   s.add_dependency('typhoeus', '>= 0.6', '< 2.0')
-  s.add_development_dependency('minitest', '~> 4.7')
-  s.add_development_dependency('rake', '~> 10.4')
+  s.add_development_dependency('minitest', '>= 4.7')
+  s.add_development_dependency('rake', '>= 10.4')
   s.add_development_dependency('rubocop', '~> 0.80')
   s.add_development_dependency('rubocop-minitest', '~> 0.1')
   s.add_development_dependency('rubocop-performance', '~> 1.5')
-  s.add_development_dependency('shoulda', '~> 3.5')
-  s.add_development_dependency('test-unit', '~> 3.1')
+  s.add_development_dependency('shoulda-context', '>= 2.0')
+  s.add_development_dependency('shoulda-matchers', '>= 4.0')
+  s.add_development_dependency('test-unit', '>= 3.1')
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,7 +10,8 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 require 'test/unit'
-require 'shoulda'
+require 'shoulda-context'
+require 'shoulda-matchers'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))


### PR DESCRIPTION
This PR migrates the CI pipeline from the no longer functioning Travis CI.org to GitHub Actions.

Dependency gem versions in the gemspec are loosened, to allow running against more recent versions. CI includes tests against versions from Ruby 2.3 to 3.1. Ruby 2.3 is the earliest version that supports the previously specified version of Rubocop.

Rubocop is also added as a CI task.

This runs green on my fork.