### PR TITLE
Add User-Agent to fetch_remote_sitemap request

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,6 +17,8 @@ Gemspec/RequiredRubyVersion:
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
   Max: 124
+  Exclude:
+    - 'test/**/*'
 
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods.

--- a/lib/sitemap-parser.rb
+++ b/lib/sitemap-parser.rb
@@ -102,10 +102,11 @@ class SitemapParser
     return nil unless remote_sitemap?
 
     request_options = options.dup.tap { |opts| opts.delete(:recurse); opts.delete(:url_regex) }
+    request_options[:headers] = { 'User-Agent' => 'Sitemap-Parser' }
     request = Typhoeus::Request.new(url, request_options)
 
     response = request.run
-    raise "HTTP request to #{url} failed" unless response.success?
+    raise "HTTP request to #{url} failed with code #{response.code}." unless response.success?
 
     inflate_body_if_needed(response)
   end

--- a/test/test_sitemap_parser.rb
+++ b/test/test_sitemap_parser.rb
@@ -39,11 +39,12 @@ class TestSitemapParser < Test::Unit::TestCase
 
   def test_404
     url = 'http://ben.balter.com/foo/bar/sitemap.xml'
-    response = Typhoeus::Response.new(code: 404, headers: {}, body: '404')
+    code = 404
+    response = Typhoeus::Response.new(code: code, headers: {}, body: code.to_s)
     Typhoeus.stub(url).and_return(response)
 
     sitemap = SitemapParser.new url
-    assert_raise RuntimeError.new("HTTP request to #{url} failed") do
+    assert_raise RuntimeError.new("HTTP request to #{url} failed with code #{code}.") do
       sitemap.urls
     end
   end
@@ -81,6 +82,7 @@ class TestSitemapParser < Test::Unit::TestCase
     end
 
     sitemap = SitemapParser.new 'https://example.com/sitemap_index.xml', recurse: true
+
     assert_equal 6, sitemap.to_a.size
     assert_equal 6, sitemap.urls.count
   end
@@ -102,6 +104,7 @@ class TestSitemapParser < Test::Unit::TestCase
     end
 
     sitemap = SitemapParser.new 'https://example.com/nested_sitemap_index.xml', recurse: true
+
     assert_equal 12, sitemap.to_a.size
     assert_equal 12, sitemap.urls.count
   end
@@ -116,6 +119,7 @@ class TestSitemapParser < Test::Unit::TestCase
     end
 
     sitemap = SitemapParser.new 'https://example.com/sitemap_index.xml', recurse: true, url_regex: /sitemap2\.xml/
+
     assert_equal 3, sitemap.to_a.size
     assert_equal 3, sitemap.urls.count
   end
@@ -130,6 +134,7 @@ class TestSitemapParser < Test::Unit::TestCase
     end
 
     sitemap = SitemapParser.new 'https://example.com/whitespace_sitemap_index.xml', recurse: true
+
     assert_equal 6, sitemap.to_a.size
     assert_equal 6, sitemap.urls.count
   end
@@ -145,6 +150,7 @@ class TestSitemapParser < Test::Unit::TestCase
 
       sitemap = SitemapParser.new url
       expected = ['http://ben.balter.com/', 'http://ben.balter.com/about/', 'http://ben.balter.com/contact/']
+
       assert_equal(expected, sitemap.to_a)
     end
   end


### PR DESCRIPTION
This adds a default User-Agent to requests when fetching remote sitemaps. Also, if an error occurs, the response code of the sitemap url is shown.

In our experience there exist many webservers which do not respond with their sitemap if no User-Agent is set. These are a few example sites for which the sitemap previously was NOT retrievable:
* https://www.faehrhaus-gruna.de/sitemap.xml (Status: 403)
* https://texxcor.com/sitemap_index.xml (status: 403)
* https://www.teichmann-recycling.de/sitemap.xml (status: 403)

With the attached change we could successfull retrieve sitemaps for above examples.